### PR TITLE
Added a Shared Version of LocalDateTome

### DIFF
--- a/internal/Types.mo
+++ b/internal/Types.mo
@@ -153,6 +153,10 @@ module {
         #locale : LocaleStartOfYear;
     };
 
+    public type LocalDateTimeShared = Components and {
+        fixedTimeZone: FixedTimeZone;
+    };
+
     public type LocalDateTime = DateTimeType<LocalDateTime> and {
         toDateTime : () -> DateTime;
 

--- a/internal/Types.mo
+++ b/internal/Types.mo
@@ -153,12 +153,14 @@ module {
         #locale : LocaleStartOfYear;
     };
 
-    public type LocalDateTimeShared = Components and {
-        fixedTimeZone: FixedTimeZone;
+    public type ComponentsWithOffset = Components and {
+        offsetSeconds : Int;
     };
 
     public type LocalDateTime = DateTimeType<LocalDateTime> and {
         toDateTime : () -> DateTime;
+
+        toComponentsWithOffset : () -> ComponentsWithOffset;
 
         timeZone : TimeZone;
 

--- a/src/Components.mo
+++ b/src/Components.mo
@@ -24,6 +24,7 @@ import Prelude "mo:base/Prelude";
 module {
 
     public type Components = InternalTypes.Components;
+    public type ComponentsWithOffset = InternalTypes.ComponentsWithOffset;
     public type DateComponents = InternalTypes.DateComponents;
     public type DayOfWeek = InternalTypes.DayOfWeek;
     public type DateTime = InternalTypes.DateTime;

--- a/src/LocalDateTime.mo
+++ b/src/LocalDateTime.mo
@@ -34,6 +34,8 @@ module {
 
     public type LocalDateTime = InternalTypes.LocalDateTime;
 
+    public type LocalDateTimeShared = InternalTypes.LocalDateTimeShared;
+
     public type TextFormat = InternalTypes.TextFormat;
 
     public type Duration = InternalTypes.Duration;

--- a/src/LocalDateTime.mo
+++ b/src/LocalDateTime.mo
@@ -32,9 +32,9 @@ module {
 
     public type Components = InternalTypes.Components;
 
-    public type LocalDateTime = InternalTypes.LocalDateTime;
+    public type ComponentsWithOffset = InternalTypes.ComponentsWithOffset;
 
-    public type LocalDateTimeShared = InternalTypes.LocalDateTimeShared;
+    public type LocalDateTime = InternalTypes.LocalDateTime;
 
     public type TextFormat = InternalTypes.TextFormat;
 
@@ -204,6 +204,19 @@ module {
         /// ```
         public func toComponents() : Components.Components {
             components;
+        };
+
+        /// Creates a `Components` from a `LocalDateTime` value with the offset in seconds from UTC
+        /// Components will represent the local datetime, not UTC datetime
+        ///
+        /// ```motoko include=import
+        /// let timeZone : TimeZone.TimeZone = #fixed(#hours(3)); // UTC+3
+        /// let dateTime : LocalDateTime.LocalDateTime = LocalDateTime.now(timeZone);
+        /// let components : Components.ComponentsWithOffset = datetime.toComponentsWithOffset();
+        /// ```
+        public func toComponentsWithOffset() : ComponentsWithOffset {
+            let offset = TimeZone.toOffsetSeconds(timeZone, components);
+            { components with offsetSeconds = offset };
         };
 
         /// Checks if the `LocalDateTime` is in a leap year.

--- a/test/LocalDateTime.conversions.test.mo
+++ b/test/LocalDateTime.conversions.test.mo
@@ -10,7 +10,7 @@ import TimeZone "../src/TimeZone";
 
 type TestCase = {
   timeZone : LocalDateTime.TimeZone;
-  dateTime : Components.Components;
+  dateTime : Components.ComponentsWithOffset;
   nanoseconds : Int;
   textIso : Text;
 };
@@ -25,6 +25,7 @@ let testCases : [TestCase] = [
       hour = 0;
       minute = 0;
       nanosecond = 0;
+      offsetSeconds = -25_200;
     };
     nanoseconds = -631_126_800_000_000_000;
     textIso = "1950-01-01T00:00:00.000000000-07:00";
@@ -38,6 +39,7 @@ let testCases : [TestCase] = [
       hour = 4;
       minute = 33;
       nanosecond = 0;
+      offsetSeconds = -18_000;
     };
     nanoseconds = -603_901_620_000_000_000;
     textIso = "1950-11-12T04:33:00.000000000-05:00";
@@ -51,6 +53,7 @@ let testCases : [TestCase] = [
       hour = 0;
       minute = 0;
       nanosecond = 0;
+      offsetSeconds = 32_400;
     };
     nanoseconds = -32_400_000_000_000;
     textIso = "1970-01-01T00:00:00.000000000+09:00";
@@ -64,6 +67,7 @@ let testCases : [TestCase] = [
       hour = 0;
       minute = 1;
       nanosecond = 0;
+      offsetSeconds = 46_800;
     };
     nanoseconds = -46_740_000_000_000;
     textIso = "1970-01-01T00:01:00.000000000+13:00";
@@ -77,6 +81,7 @@ let testCases : [TestCase] = [
       hour = 0;
       minute = 0;
       nanosecond = 0;
+      offsetSeconds = -3_600;
     };
     nanoseconds = 90_000_000_000_000;
     textIso = "1970-01-02T00:00:00.000000000-01:00";
@@ -90,6 +95,7 @@ let testCases : [TestCase] = [
       hour = 7;
       minute = 34;
       nanosecond = 0;
+      offsetSeconds = 27_240;
     };
     nanoseconds = 68_169_600_000_000_000;
     textIso = "1972-02-29T07:34:00.000000000+07:34";
@@ -103,6 +109,7 @@ let testCases : [TestCase] = [
       hour = 0;
       minute = 0;
       nanosecond = 0;
+      offsetSeconds = -25_320;
     };
     nanoseconds = 946_710_120_000_000_000;
     textIso = "2000-01-01T00:00:00.000000000-07:02";
@@ -116,6 +123,7 @@ let testCases : [TestCase] = [
       hour = 23;
       minute = 59;
       nanosecond = 59_000_000_000;
+      offsetSeconds = 120;
     };
     nanoseconds = 978_307_079_000_000_000;
     textIso = "2000-12-31T23:59:59.000000000+00:02";
@@ -129,6 +137,7 @@ let testCases : [TestCase] = [
       hour = 15;
       minute = 30;
       nanosecond = 0;
+      offsetSeconds = 14_580;
     };
     nanoseconds = 1_589_974_020_000_000_000;
     textIso = "2020-05-20T15:30:00.000000000+04:03";
@@ -183,8 +192,16 @@ for (testCase in Iter.fromArray(testCases)) {
   test(
     "toComponents (LocalDateTime -> Components): " # testCaseText,
     func() {
-      // From nanoseconds
       assertComponents(expectedDateTime.toComponents(), testCase.dateTime);
+    },
+  );
+
+  test(
+    "toComponentsWithOffset (LocalDateTime -> Components): " # testCaseText,
+    func() {
+      let componentsWithOffset = expectedDateTime.toComponentsWithOffset();
+      assertComponents(componentsWithOffset, testCase.dateTime);
+      assert (componentsWithOffset.offsetSeconds == testCase.dateTime.offsetSeconds);
     },
   );
 


### PR DESCRIPTION
I want to use this as a stable/shared type in another library and it seems that having the functions keeps it from being stored as stable/returned from functions properly.  Some more work can be done to add conversion functions, but for now I'll leave it as is.